### PR TITLE
Include segment text in progress logger

### DIFF
--- a/whisper_assistant.py
+++ b/whisper_assistant.py
@@ -137,7 +137,9 @@ def transcribe_with_progress(model_dir: str, media_path: str, fmt: str, language
             if p > last_p:
                 last_p = p
                 progress_cb(p)
-        logger(f"[SEG {i}] {format_timestamp(seg.start)} --> {format_timestamp(seg.end)}")
+        logger(
+            f"[SEG {i}] {format_timestamp(seg.start)} --> {format_timestamp(seg.end)} {seg.text.strip()}"
+        )
     progress_cb(100)
     base, _ = os.path.splitext(media_path)
     outfile = base + (".srt" if fmt == "srt" else ".txt")


### PR DESCRIPTION
## Summary
- Log each segment's transcribed text along with start and end timestamps in `transcribe_with_progress`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68aeaeabea748322af55b8097405008a