### PR TITLE
Infer compute type from model folder name

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ pip install torch --index-url https://download.pytorch.org/whl/cu121
 > Windows 11 原生环境目前仅提供 CPU 版本的 `ctranslate2`，如需 GPU 加速建议在 [WSL2](https://learn.microsoft.com/windows/wsl/) 中安装以上依赖；若仅在 Windows 上运行，可忽略 GPU 依赖。
 
 ### 模型放置
-- **CTranslate2**：将转换好的模型目录放入 `models/` 子目录（默认从该目录加载），目录名末尾需指明模型类型，如 `belle-whisper-large-v3-turbo-ct2-i8f16`、`belle-whisper-large-v3-turbo-ct2-int16` 或 `belle-whisper-large-v3-turbo-ct2-float16`。程序会根据目录名末尾自动选择对应的计算模式。
+- **CTranslate2**：将转换好的模型目录放入 `models/` 子目录（默认从该目录加载），目录名末尾需指明模型类型，如 `belle-whisper-large-v3-turbo-ct2-i8f16`、`belle-whisper-large-v3-turbo-ct2-int16` 或 `belle-whisper-large-v3-turbo-ct2-f16`。程序会根据目录名末尾自动选择对应的计算模式；若未识别后缀，将打印警告并默认使用 CPU `int8`。
 - **ggml**：下载 `ggml`/`gguf` 模型文件（例如 `ggml-base.bin`），在界面中直接选择该文件即可。
 
 ### CUDA（可选）
-- 有 NVIDIA 显卡并安装 **CUDA 12.x + cuDNN 8** 时，程序会自动使用 GPU（`device=cuda, compute_type=float16`），否则回退到 CPU（`int8`）。
+- 使用后缀 `-f16` 的模型需要安装 **CUDA 12.x + cuDNN 8**；否则程序会默认使用 CPU（`int8`）。
 
 ## 打包为 exe（Windows）
 ```bash

--- a/whisper_assistant.py
+++ b/whisper_assistant.py
@@ -108,21 +108,9 @@ def pick_device_and_compute_type(model_path: str):
         return "cpu", "int16"
     if suffix in {"i8f16", "int8_float16", "int8float16"}:
         return "cpu", "int8_float16"
-    if suffix == "float16":
+    if suffix in {"f16", "float16"}:
         return "cuda", "float16"
-    try:
-        import ctranslate2 as c2  # type: ignore
-        get_cnt = getattr(c2, "get_cuda_device_count", None)
-        if callable(get_cnt) and get_cnt() > 0:
-            return "cuda", "float16"
-    except Exception:
-        pass
-    try:
-        import torch  # type: ignore
-        if torch.cuda.is_available():
-            return "cuda", "float16"
-    except Exception:
-        pass
+    print(f"[WARN] 无法识别模型类型后缀：{suffix}，默认使用 CPU int8")
     return "cpu", "int8"
 
 _model_cache = {}


### PR DESCRIPTION
## Summary
- infer device and compute type from model directory suffix (int16/i8f16/float16)
- update documentation for new model naming scheme

## Testing
- `python -m py_compile whisper_assistant.py`


------
https://chatgpt.com/codex/tasks/task_b_68b000bc91fc832293922ac584231ef9