### PR TITLE
Handle ggml GPU fallback

### DIFF
--- a/whisper_assistant.py
+++ b/whisper_assistant.py
@@ -127,7 +127,15 @@ def load_model(model_path: str, backend: str):
         from pywhispercpp.model import Model  # type: ignore
 
         n_threads = os.cpu_count() or 4
-        model = Model(model_path, n_threads=n_threads)
+        try:
+            model = Model(model_path, n_threads=n_threads, n_gpu_layers=99)
+        except (RuntimeError, OSError) as e:
+            print(f"[WARN] GPU initialization failed, falling back to CPU mode: {e}")
+            try:
+                messagebox.showwarning("GPU 初始化失败", "GPU 初始化失败，将使用 CPU 模式。")
+            except Exception:
+                pass
+            model = Model(model_path, n_threads=n_threads, n_gpu_layers=0)
         _model_cache[key] = model
         return model, "cpu", "ggml"
     device, first_ct = pick_device_and_compute_type()


### PR DESCRIPTION
## Summary
- Retry ggml model load with CPU settings when GPU initialization fails
- Warn user and switch to CPU mode if GPU is unavailable

## Testing
- `python -m py_compile whisper_assistant.py`


------
https://chatgpt.com/codex/tasks/task_b_68b15d0b80b8832285466ae88bd95a7d