### PR TITLE
Fix ggml Chinese transcription translating to English

### DIFF
--- a/whisper_assistant.py
+++ b/whisper_assistant.py
@@ -256,7 +256,13 @@ def transcribe_with_progress(
             if stop_event and stop_event.is_set():
                 raise TranscriptionStopped()
 
-        model.transcribe(media_path, language=(language or ""), new_segment_callback=cb, print_progress=False)
+        model.transcribe(
+            media_path,
+            language=(language or ""),
+            translate=False,
+            new_segment_callback=cb,
+            print_progress=False,
+        )
         progress_cb(100)
         segments = seg_list
     else:


### PR DESCRIPTION
## Summary
- disable translation in ggml backend transcription so Chinese audio stays in Chinese

## Testing
- `python -m py_compile whisper_assistant.py`


------
https://chatgpt.com/codex/tasks/task_b_68b16dd4d7608322bb1304dceee45520