### PR TITLE
Use int16 compute type on CPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ pip install torch --index-url https://download.pytorch.org/whl/cu121
 > Windows 11 原生环境目前仅提供 CPU 版本的 `ctranslate2`，如需 GPU 加速建议在 [WSL2](https://learn.microsoft.com/windows/wsl/) 中安装以上依赖；若仅在 Windows 上运行，可忽略 GPU 依赖。
 
 ### 模型放置
-- **CTranslate2**：将转换好的模型目录命名为 `belle-whisper-large-v3-turbo-ct2i8f16` 并放在 `models/` 子目录（默认从该目录加载），或在界面中手动选择目录。
+ - **CTranslate2**：将转换好的模型目录命名为 `belle-whisper-large-v3-turbo-ct2-int16` 并放在 `models/` 子目录（默认从该目录加载），或在界面中手动选择目录。
 - **ggml**：下载 `ggml`/`gguf` 模型文件（例如 `ggml-base.bin`），在界面中直接选择该文件即可。
 
 ### CUDA（可选）
-- 有 NVIDIA 显卡并安装 **CUDA 12.x + cuDNN 8** 时，程序会自动使用 GPU（`device=cuda, compute_type=float16`），否则回退到 CPU（`int8`）。
+ - 有 NVIDIA 显卡并安装 **CUDA 12.x + cuDNN 8** 时，程序会自动使用 GPU（`device=cuda, compute_type=float16`），否则回退到 CPU（`int16`）。
 - ggml 后端若在安装 `pywhispercpp` 时启用了 `GGML_CUDA=1`，同样会自动尝试使用 GPU。
 
 ## 打包为 exe（Windows）
@@ -65,7 +65,7 @@ WhisperSpeechAssistant/
 ├─ README.md
 ├─ LICENSE
 └─ models/
-   ├─ belle-whisper-large-v3-turbo-ct2i8f16/  # CTranslate2 模型目录
+    ├─ belle-whisper-large-v3-turbo-ct2-int16/  # CTranslate2 模型目录
    │   └─ ...
    └─ ggml-base.bin                           # ggml 模型文件示例
 ```

--- a/models/README.md
+++ b/models/README.md
@@ -1,5 +1,5 @@
 # 模型放置说明
 
-请将转换为 CTranslate2 的 Whisper 模型放在本目录。默认程序会在 `models/belle-whisper-large-v3-turbo-ct2-i8f16` 中寻找模型。`ffmpeg.exe` 应放在程序目录（与 `whisper_assistant.py` 同级）。
+请将转换为 CTranslate2 的 Whisper 模型放在本目录。默认程序会在 `models/belle-whisper-large-v3-turbo-ct2-int16` 中寻找模型。`ffmpeg.exe` 应放在程序目录（与 `whisper_assistant.py` 同级）。
 
 也可以在应用界面中手动选择模型目录。

--- a/whisper_assistant.py
+++ b/whisper_assistant.py
@@ -101,7 +101,7 @@ def get_media_duration(media_path: str) -> float | None:
 
 def pick_device_and_compute_type(mode: str = "auto"):
     if mode == "cpu" or os.environ.get("WHISPER_FORCE_CPU") == "1":
-        return "cpu", "int8"
+        return "cpu", "int16"
     if mode in ("gpu", "auto"):
         try:
             import ctranslate2 as c2  # type: ignore
@@ -116,7 +116,7 @@ def pick_device_and_compute_type(mode: str = "auto"):
                 return "cuda", "float16"
         except Exception:
             pass
-    return "cpu", "int8"
+    return "cpu", "int16"
 
 _model_cache = {}
 
@@ -168,9 +168,9 @@ def load_model(model_path: str, backend: str, device_mode: str = "auto"):
     if device_mode == "gpu" and device != "cuda":
         raise RuntimeError("GPU 初始化失败，请切换到 CPU 模式")
     if device == "cuda":
-        fallbacks = [first_ct, "float32", "int8"]
+        fallbacks = [first_ct, "float32", "int16"]
     else:
-        fallbacks = [first_ct, "int16", "float32", "float16"]
+        fallbacks = [first_ct, "float32", "float16"]
     last_err = None
     for ct in fallbacks:
         key = (model_path, device, ct)
@@ -313,7 +313,7 @@ class WhisperApp(tk.Tk):
         self.worker_thread = None
         self.last_output = None
         exe_dir = os.path.dirname(sys.executable) if getattr(sys, "frozen", False) else os.path.dirname(os.path.abspath(__file__))
-        default_model_dir = os.path.join(exe_dir, "models", "belle-whisper-large-v3-turbo-ct2-i8f16")
+        default_model_dir = os.path.join(exe_dir, "models", "belle-whisper-large-v3-turbo-ct2-int16")
         tk.Label(self, text="后端:").grid(row=0, column=0, sticky="w", padx=12, pady=8)
         self.backend_var = tk.StringVar(value="ct2")
         tk.Radiobutton(self, text="CTranslate2", variable=self.backend_var, value="ct2").grid(row=0, column=1, sticky="w")


### PR DESCRIPTION
## Summary
- Prefer int16 compute type on CPU and float16 on CUDA devices
- Default to the `belle-whisper-large-v3-turbo-ct2-int16` model directory and update docs accordingly

## Testing
- `python -m py_compile whisper_assistant.py`


------
https://chatgpt.com/codex/tasks/task_b_68b173039e808322b13b0097ee1ef372