### PR TITLE
Fallback to CPU int8 when GPU float16 fails

### DIFF
--- a/whisper_assistant.py
+++ b/whisper_assistant.py
@@ -157,6 +157,18 @@ def pick_device_and_compute_type(mode: str = "auto"):
             import ctranslate2 as c2  # type: ignore
             get_cnt = getattr(c2, "get_cuda_device_count", None)
             if callable(get_cnt) and get_cnt() > 0:
+                get_supported = getattr(c2, "get_supported_compute_types", None)
+                if callable(get_supported):
+                    try:
+                        supported = get_supported("cuda")
+                    except Exception:
+                        supported = []
+                    if "float16" in supported:
+                        return "cuda", "float16"
+                    if "float32" in supported:
+                        return "cuda", "float32"
+                    if supported:
+                        return "cuda", supported[0]
                 return "cuda", "float16"
         except Exception:
             pass

--- a/whisper_assistant.py
+++ b/whisper_assistant.py
@@ -243,17 +243,31 @@ def load_model(
         return model, device, "ggml", warn_msg, None
     device, default_ct = pick_device_and_compute_type(device_mode)
 
-    # If the user explicitly chose both device and precision, load directly
-    # without checking for supported compute types or falling back.
+    # If the user explicitly chose both device and precision, try to honor it
+    # but fall back to CPU+int8 if the GPU float16 request fails.
     if device_mode in ("cpu", "gpu") and compute_type is not None:
         if device_mode == "gpu" and device != "cuda":
             raise RuntimeError("GPU 初始化失败，请切换到 CPU 模式")
         key = (model_path, device, compute_type)
         if key in _model_cache:
             return _model_cache[key], device, compute_type, warn_msg, None
-        model = WhisperModel(model_path, device=device, compute_type=compute_type)
-        _model_cache[key] = model
-        return model, device, compute_type, warn_msg, None
+        try:
+            model = WhisperModel(model_path, device=device, compute_type=compute_type)
+            _model_cache[key] = model
+            return model, device, compute_type, warn_msg, None
+        except Exception as e:
+            if device_mode == "gpu" and compute_type == "float16":
+                warn_msg = "GPU 初始化失败，已切回 CPU + int8 模式"
+                device = "cpu"
+                compute_type = "int8"
+                key = (model_path, device, compute_type)
+                if key in _model_cache:
+                    return _model_cache[key], device, compute_type, warn_msg, str(e)
+                model = WhisperModel(model_path, device=device, compute_type=compute_type)
+                _model_cache[key] = model
+                return model, device, compute_type, warn_msg, str(e)
+            else:
+                raise
 
     model_ct = None if backend == "ggml" else guess_model_precision(model_path)
     first_ct = compute_type or model_ct or default_ct
@@ -263,9 +277,10 @@ def load_model(
 
     fallbacks = [first_ct]
     if device == "cuda":
-        for ct in ["float16", "float32", "int8"]:
-            if ct not in fallbacks:
-                fallbacks.append(ct)
+        if first_ct != "float16":
+            for ct in ["float16", "float32", "int8"]:
+                if ct not in fallbacks:
+                    fallbacks.append(ct)
     else:
         for ct in ["int8", "int16", "int32", "float32", "float16"]:
             if ct not in fallbacks:


### PR DESCRIPTION
## Summary
- gracefully fall back to CPU int8 when GPU float16 initialization fails
- avoid trying GPU float32/int8 when float16 is requested

## Testing
- `python -m py_compile whisper_assistant.py`


------
https://chatgpt.com/codex/tasks/task_b_68b666e50eb88322b382b688e1224691