### PR TITLE
Fix newline handling in TXT output

### DIFF
--- a/whisper_assistant.py
+++ b/whisper_assistant.py
@@ -149,7 +149,7 @@ def write_txt(segments, outfile: str):
         for seg in segments:
             text = (seg.text or "").strip()
             if text:
-                f.write(text + "\\n")
+                f.write(text + "\n")
 
 def open_in_explorer(path: str):
     try:


### PR DESCRIPTION
## Summary
- write text transcripts using real newline characters instead of escaped `\n`

## Testing
- `python -m py_compile whisper_assistant.py`
- Wrote a sample transcript and verified resulting `test.txt` contains separate lines

------
https://chatgpt.com/codex/tasks/task_b_68bfe1c19e948322b10063f346af7bf6