### PR TITLE
Optimize token selection in sample_best

### DIFF
--- a/whisper_assistant.py
+++ b/whisper_assistant.py
@@ -69,7 +69,8 @@ def sample_best(
     ts_max = ts_probs.max() if ts_probs.size > 0 else 0.0
     if ts_max < thold_pt or ts_probs.sum() < thold_ptsum:
         probs[timestamp_mask] = 0.0
-    top_indices = np.argsort(probs)[-top_k:]
+    # Use argpartition to partially sort and retrieve only the top-k indices
+    top_indices = np.argpartition(probs, -top_k)[-top_k:]
     best_idx = top_indices[np.argmax(probs[top_indices])]
     return int(best_idx)
 


### PR DESCRIPTION
## Summary
- Use `np.argpartition` in `sample_best` to retrieve only the top-k probabilities
- Keep argmax on the partitioned subset for final token selection

## Testing
- `python -m py_compile whisper_assistant.py`
- `python - <<'PY'
from whisper_assistant import sample_best
import numpy as np
logits = np.array([1,2,3,4,5])
mask = np.array([False, False, False, False, False])
print('selected:', sample_best(logits, mask, top_k=2))
PY`


------
https://chatgpt.com/codex/tasks/task_b_68bfe778f8a08322ad3887830f6ad0e6