### PR TITLE
Add VAD-based segmentation to reduce overlap

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 faster-whisper>=1.0.0
+webrtcvad>=2.0.10
 # ggml backend
 pywhispercpp>=1.3.3
 # Tkinter 是标准库自带；Windows/macOS 无需安装；Linux 可安装 python3-tk。


### PR DESCRIPTION
## Summary
- introduce a WebRTC VAD based pre-segmentation stage to split audio by speech activity before transcription
- fall back to the existing fixed-size chunking when VAD is unavailable while still updating progress correctly
- add the `webrtcvad` runtime dependency required for the new segmentation helper

## Testing
- python -m compileall whisper_assistant.py

------
https://chatgpt.com/codex/tasks/task_b_68c8c9b7bcc8832289e74f657ef009ee